### PR TITLE
pyhamcrest 2.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "2.0.4" %}
 
 package:
   name: pyhamcrest
@@ -7,7 +7,7 @@ package:
 source:
   fn: PyHamcrest-{{ version }}.tar.gz
   url: https://pypi.python.org/packages/source/P/PyHamcrest/PyHamcrest-{{ version }}.tar.gz
-  md5: 7a086f0b067f8d38958ec32f054559b4
+  md5: d41d8cd98f00b204e9800998ecf8427e
 
 build:
   noarch: python


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 1d22bb1..561b3e7 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "2.0.4" %}
 
 package:
   name: pyhamcrest
@@ -7,7 +7,7 @@ package:
 source:
   fn: PyHamcrest-{{ version }}.tar.gz
   url: https://pypi.python.org/packages/source/P/PyHamcrest/PyHamcrest-{{ version }}.tar.gz
-  md5: 7a086f0b067f8d38958ec32f054559b4
+  md5: d41d8cd98f00b204e9800998ecf8427e
 
 build:
   noarch: python

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.0.4
 * Release on PyPi:
    * version: 2.0.4
    * date: 2022-08-07T15:48:25
* [PyPi history](https://pypi.org/project/pyhamcrest/#history)
 * Popularity: 
    * 3 months downloads: 191118.0
    * All time:  443537 downloads -  pyhamcrest  2.0.4  Hamcrest framework for matcher objects  

</details>

**Other checks:**

<details>

1. - [ ] The upstream url error:
    https://github.com/hamcrest/PyHamcrest/tree/v2.0.4
    404
2. - [x] https://github.com/hamcrest/PyHamcrest is present
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/hamcrest/PyHamcrest/tree/v2.0.4
    404
5. - [ ] Additional research
    https://github.com/hamcrest/PyHamcrest/issues
    200
6. - [x] `dev_url` is present
    https://github.com/hamcrest/PyHamcrest
7. - [ ] `doc_url` error:
    
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [ ] Verify if the package needs `wheel`
    
11. - [ ] NO `pip` in test
    
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [ ] license_file doesn't exist!
16. - [x] License: BSD
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| 0BSD                                 |
| BSD-1-Clause                         |
| BSD-2-Clause                         |
| BSD-2-Clause-Patent                  |
| BSD-2-Clause-Views                   |
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
| BSD-4-Clause                         |
| BSD-4-Clause-Shortened               |
| BSD-4-Clause-UC                      |
| BSD-Protection                       |
| BSD-Source-Code                      |
| FreeBSD-DOC                          |

17. - [ ] License family is NOT present
    
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pyhamcrest-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pyhamcrest-feedstock/tree/2.0.4)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pyhamcrest)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pyhamcrest-feedstock/compare/main...AnacondaRecipes:2.0.4)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pyhamcrest-feedstock/compare/master...AnacondaRecipes:2.0.4)
* [The last merged PRs](https://github.com/AnacondaRecipes/pyhamcrest-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.0.4 git@github.com:AnacondaRecipes/pyhamcrest-feedstock.git
```
